### PR TITLE
Add source vs source comparison mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Spring Boot web application for comparing Java sources and classes.
 - Compare .class files from both ZIPs.
 - Parse with ASM to extract signatures/methods/fields → diff the structure.
 
+## Source vs Source Mode:
+
+- Compare .java source files from both ZIPs.
+- Format and normalize each side using google-java-format.
+- Diff the results.
+
 ## 3. Normalization (before diffing)
 
 ### Java (.class / .java):

--- a/src/main/java/com/example/sourcecompare/ComparisonMode.java
+++ b/src/main/java/com/example/sourcecompare/ComparisonMode.java
@@ -2,5 +2,6 @@ package com.example.sourcecompare;
 
 public enum ComparisonMode {
     CLASS_VS_SOURCE,
-    CLASS_VS_CLASS;
+    CLASS_VS_CLASS,
+    SOURCE_VS_SOURCE;
 }

--- a/src/main/java/com/example/sourcecompare/ComparisonService.java
+++ b/src/main/java/com/example/sourcecompare/ComparisonService.java
@@ -26,6 +26,7 @@ public class ComparisonService {
         return switch (mode) {
             case CLASS_VS_SOURCE -> compareClassToSource(leftZip, rightZip);
             case CLASS_VS_CLASS -> compareClassToClass(leftZip, rightZip);
+            case SOURCE_VS_SOURCE -> compareSourceToSource(leftZip, rightZip);
         };
     }
 
@@ -62,6 +63,26 @@ public class ComparisonService {
         rightRaw.values().stream()
                 .map(fi -> eclipseFormatService.formatFile(fi.getName(), fi.getContent()))
                 .forEach(fi -> right.put(fi.getName(), fi));
+
+        return diffFileMaps(left, right);
+    }
+
+    private ComparisonResult compareSourceToSource(MultipartFile leftZip, MultipartFile rightZip)
+            throws IOException {
+        Map<String, FileInfo> leftRaw = readSources(leftZip);
+        Map<String, FileInfo> rightRaw = readSources(rightZip);
+
+        Map<String, FileInfo> left = new HashMap<>();
+        for (Map.Entry<String, FileInfo> e : leftRaw.entrySet()) {
+            String name = e.getKey();
+            left.put(name, new FileInfo(name, googleFormatService.normalizeJava(e.getValue().getContent())));
+        }
+
+        Map<String, FileInfo> right = new HashMap<>();
+        for (Map.Entry<String, FileInfo> e : rightRaw.entrySet()) {
+            String name = e.getKey();
+            right.put(name, new FileInfo(name, googleFormatService.normalizeJava(e.getValue().getContent())));
+        }
 
         return diffFileMaps(left, right);
     }

--- a/src/main/java/com/example/sourcecompare/ComparisonService.java
+++ b/src/main/java/com/example/sourcecompare/ComparisonService.java
@@ -69,22 +69,29 @@ public class ComparisonService {
 
     private ComparisonResult compareSourceToSource(MultipartFile leftZip, MultipartFile rightZip)
             throws IOException {
+        long start  = System.currentTimeMillis();
         Map<String, FileInfo> leftRaw = readSources(leftZip);
         Map<String, FileInfo> rightRaw = readSources(rightZip);
+        System.out.println("Step 1: Read files:"+(System.currentTimeMillis()-start)/1000);
 
         Map<String, FileInfo> left = new HashMap<>();
-        for (Map.Entry<String, FileInfo> e : leftRaw.entrySet()) {
-            String name = e.getKey();
-            left.put(name, new FileInfo(name, googleFormatService.normalizeJava(e.getValue().getContent())));
-        }
+        leftRaw.values().stream()
+                .map(fi -> eclipseFormatService.formatFile(fi.getName(), fi.getContent()))
+                .forEach(fi -> left.put(fi.getName(), fi));
+
+        System.out.println("Step 2: Execute left:"+(System.currentTimeMillis()-start)/1000);
 
         Map<String, FileInfo> right = new HashMap<>();
-        for (Map.Entry<String, FileInfo> e : rightRaw.entrySet()) {
-            String name = e.getKey();
-            right.put(name, new FileInfo(name, googleFormatService.normalizeJava(e.getValue().getContent())));
-        }
+        rightRaw.values().stream()
+                .map(fi -> eclipseFormatService.formatFile(fi.getName(), fi.getContent()))
+                .forEach(fi -> right.put(fi.getName(), fi));
+        System.out.println("Step 3: Execute right:"+(System.currentTimeMillis()-start)/1000);
 
-        return diffFileMaps(left, right);
+        ComparisonResult result = diffFileMaps(left, right);
+
+        System.out.println("Step 4: Compare:"+(System.currentTimeMillis()-start)/1000);
+
+        return result;
     }
 
     private Map<String, FileInfo> readSources(MultipartFile zip) throws IOException {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -74,12 +74,17 @@
             </div>
         </div>
         <div class="row mb-3">
-            <div class="col-md-4">
-                <select class="form-select" id="mode" name="mode">
-                    <option value="CLASS_VS_CLASS">Class vs Class</option>
-                    <option value="CLASS_VS_SOURCE">Class vs Source</option>
-                    <option value="SOURCE_VS_SOURCE">Source vs Source</option>
-                </select>
+            <div class="col-md-12">
+                <div class="btn-group" role="group" aria-label="Comparison mode">
+                    <input type="radio" class="btn-check" name="mode" id="modeClassClass" value="CLASS_VS_CLASS" checked>
+                    <label class="btn btn-outline-primary" for="modeClassClass">Class vs Class</label>
+
+                    <input type="radio" class="btn-check" name="mode" id="modeClassSource" value="CLASS_VS_SOURCE">
+                    <label class="btn btn-outline-primary" for="modeClassSource">Class vs Source</label>
+
+                    <input type="radio" class="btn-check" name="mode" id="modeSourceSource" value="SOURCE_VS_SOURCE">
+                    <label class="btn btn-outline-primary" for="modeSourceSource">Source vs Source</label>
+                </div>
             </div>
         </div>
         <button class="btn btn-primary" type="submit">Compare</button>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -75,13 +75,11 @@
         </div>
         <div class="row mb-3">
             <div class="col-md-4">
-                <label class="form-label" for="mode">Mode</label>
                 <select class="form-select" id="mode" name="mode">
                     <option value="CLASS_VS_CLASS">Class vs Class</option>
                     <option value="CLASS_VS_SOURCE">Class vs Source</option>
                     <option value="SOURCE_VS_SOURCE">Source vs Source</option>
                 </select>
-                <div class="form-text">Select the comparison mode.</div>
             </div>
         </div>
         <button class="btn btn-primary" type="submit">Compare</button>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -79,6 +79,7 @@
                 <select class="form-select" id="mode" name="mode">
                     <option value="CLASS_VS_CLASS">Class vs Class</option>
                     <option value="CLASS_VS_SOURCE">Class vs Source</option>
+                    <option value="SOURCE_VS_SOURCE">Source vs Source</option>
                 </select>
                 <div class="form-text">Select the comparison mode.</div>
             </div>


### PR DESCRIPTION
## Summary
- add SOURCE_VS_SOURCE option to comparison modes and service logic
- update web form to allow selecting Source vs Source
- document new mode in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c8205da02483259cb7954ced08fc70