### PR TITLE
Add configurable diff context size

### DIFF
--- a/src/main/java/com/example/sourcecompare/HomeController.java
+++ b/src/main/java/com/example/sourcecompare/HomeController.java
@@ -28,9 +28,11 @@ public class HomeController {
             @RequestParam("leftZip") MultipartFile leftZip,
             @RequestParam("rightZip") MultipartFile rightZip,
             @RequestParam("mode") ComparisonMode mode,
+            @RequestParam(name = "contextSize", defaultValue = "5") int contextSize,
             Model model)
             throws IOException {
-        ComparisonResult result = comparisonService.compare(leftZip, rightZip, mode);
+        ComparisonResult result =
+                comparisonService.compare(leftZip, rightZip, mode, contextSize);
         model.addAttribute(
                 "message",
                 String.format(

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -88,6 +88,20 @@
                 </div>
             </div>
         </div>
+        <div class="row mb-3">
+            <div class="col-md-4 col-lg-3">
+                <label class="form-label" for="contextSize">Context size</label>
+                <input
+                        class="form-control"
+                        id="contextSize"
+                        min="0"
+                        name="contextSize"
+                        type="number"
+                        value="5"
+                />
+                <div class="form-text">Number of unchanged lines included around each diff hunk.</div>
+            </div>
+        </div>
         <button class="btn btn-primary" type="submit">Compare</button>
     </form>
 


### PR DESCRIPTION
## Summary
- add a user-configurable context size parameter to the comparison workflow with a default of 5
- propagate the context size through `ComparisonService` and use it when generating unified diffs
- expose a numeric context size input in the comparison form

## Testing
- `mvn -q test` *(fails: unable to resolve Spring Boot parent POM because the Maven Central repository is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c985b69c0483259976b4431fc58b6d