### PR TITLE
Handle non-class entries in decompile service

### DIFF
--- a/src/main/java/com/example/sourcecompare/DecompileService.java
+++ b/src/main/java/com/example/sourcecompare/DecompileService.java
@@ -69,8 +69,8 @@ public class DecompileService {
                     unorderedResults.put(
                             entryName, new FileInfo(entryName, new String(entryBytes, StandardCharsets.UTF_8)));
                 } else {
-                    drainEntry(zis);
-                    zis.closeEntry();
+//                    drainEntry(zis);
+//                    zis.closeEntry();
                     unorderedResults.put(entryName, new FileInfo(entryName, CONTENT_NOT_READ));
                 }
             }
@@ -231,7 +231,7 @@ public class DecompileService {
             return false; // no extension
         }
 
-        String extension = fileName.substring(dotIndex + 1).toLowerCase();
+        String extension = fileName.substring(dotIndex).toLowerCase();
         return HUMAN_READABLE_SUFFIXES.contains(extension);
     }
 

--- a/src/main/java/com/example/sourcecompare/DecompileService.java
+++ b/src/main/java/com/example/sourcecompare/DecompileService.java
@@ -224,14 +224,17 @@ public class DecompileService {
                     ".yaml",
                     ".yml");
 
-    private static boolean isHumanReadable(String lowerCaseName) {
-        for (String suffix : HUMAN_READABLE_SUFFIXES) {
-            if (lowerCaseName.endsWith(suffix)) {
-                return true;
-            }
+    private static boolean isHumanReadable(String fileName) {
+        // Extract extension (after last '.')
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex == -1 || dotIndex == fileName.length() - 1) {
+            return false; // no extension
         }
-        return false;
+
+        String extension = fileName.substring(dotIndex + 1).toLowerCase();
+        return HUMAN_READABLE_SUFFIXES.contains(extension);
     }
+
 
     private static void drainEntry(ZipInputStream zis) throws IOException {
         byte[] buffer = new byte[8192];

--- a/src/main/java/com/example/sourcecompare/DecompileService.java
+++ b/src/main/java/com/example/sourcecompare/DecompileService.java
@@ -63,15 +63,15 @@ public class DecompileService {
                                 }
                             });
                     submittedTasks++;
-                } else if (shouldUsePlaceholder(lowerCaseName)) {
-                    drainEntry(zis);
-                    zis.closeEntry();
-                    unorderedResults.put(entryName, new FileInfo(entryName, CONTENT_NOT_READ));
-                } else {
+                } else if (isHumanReadable(lowerCaseName)) {
                     byte[] entryBytes = zis.readAllBytes();
                     zis.closeEntry();
                     unorderedResults.put(
                             entryName, new FileInfo(entryName, new String(entryBytes, StandardCharsets.UTF_8)));
+                } else {
+                    drainEntry(zis);
+                    zis.closeEntry();
+                    unorderedResults.put(entryName, new FileInfo(entryName, CONTENT_NOT_READ));
                 }
             }
         }
@@ -166,37 +166,66 @@ public class DecompileService {
 
     private static final String CONTENT_NOT_READ = "CONTENT_NOT_READ";
 
-    private static final List<String> PLACEHOLDER_SUFFIXES =
-            List.of(
-                    ".tar",
-                    ".zip",
-                    ".gz",
-                    ".tgz",
-                    ".rar",
-                    ".7z",
-                    ".bz2",
-                    ".xz",
-                    ".png",
-                    ".jpg",
-                    ".jpeg",
-                    ".gif",
-                    ".bmp",
-                    ".tif",
-                    ".tiff",
-                    ".webp",
-                    ".heic",
-                    ".xlsx",
-                    ".xls",
-                    ".xlsm",
-                    ".doc",
-                    ".docx",
-                    ".ppt",
-                    ".pptx",
-                    ".pdf",
-                    ".word");
+    private static final Set<String> HUMAN_READABLE_SUFFIXES =
+            Set.of(
+                    ".bat",
+                    ".bash",
+                    ".c",
+                    ".cc",
+                    ".cfg",
+                    ".conf",
+                    ".cpp",
+                    ".css",
+                    ".cs",
+                    ".csv",
+                    ".ftl",
+                    ".go",
+                    ".gradle",
+                    ".groovy",
+                    ".h",
+                    ".hpp",
+                    ".htm",
+                    ".html",
+                    ".ini",
+                    ".java",
+                    ".js",
+                    ".json",
+                    ".jsp",
+                    ".jspx",
+                    ".jsx",
+                    ".kt",
+                    ".kts",
+                    ".less",
+                    ".log",
+                    ".manifest",
+                    ".markdown",
+                    ".md",
+                    ".mf",
+                    ".pom",
+                    ".properties",
+                    ".ps1",
+                    ".py",
+                    ".rb",
+                    ".scala",
+                    ".scss",
+                    ".sh",
+                    ".sql",
+                    ".swift",
+                    ".ts",
+                    ".tsv",
+                    ".tsx",
+                    ".txt",
+                    ".vm",
+                    ".xhtml",
+                    ".xml",
+                    ".xsd",
+                    ".xsl",
+                    ".xslt",
+                    ".yaml",
+                    ".yml");
 
-    private static boolean shouldUsePlaceholder(String lowerCaseName) {
-        for (String suffix : PLACEHOLDER_SUFFIXES) {
+    private static boolean isHumanReadable(String lowerCaseName) {
+        for (String suffix : HUMAN_READABLE_SUFFIXES) {
             if (lowerCaseName.endsWith(suffix)) {
                 return true;
             }

--- a/src/test/java/com/example/sourcecompare/DecompileServiceTest.java
+++ b/src/test/java/com/example/sourcecompare/DecompileServiceTest.java
@@ -26,6 +26,9 @@ class DecompileServiceTest {
         Map<String, byte[]> entries = new LinkedHashMap<>();
         entries.put("pkg/Foo.class", new byte[] {(byte) 30});
         entries.put("pkg/readme.txt", "resource".getBytes(StandardCharsets.UTF_8));
+        entries.put("pkg/page.html", "<html/>".getBytes(StandardCharsets.UTF_8));
+        entries.put("pkg/layout.xml", "<xml/>".getBytes(StandardCharsets.UTF_8));
+        entries.put("pkg/config.properties", "foo=bar".getBytes(StandardCharsets.UTF_8));
         entries.put("pkg/archive.tar", new byte[] {1, 2, 3});
         entries.put("pkg/picture.jpg", new byte[] {4});
         entries.put("pkg/docs/report.pdf", new byte[] {5, 6});
@@ -52,7 +55,10 @@ class DecompileServiceTest {
         assertEquals(entries.size(), result.size());
         assertIterableEquals(entries.keySet(), result.keySet(), "Decompiled files should follow ZIP order");
         Set<String> placeholderEntries =
-                Set.of("pkg/archive.tar", "pkg/picture.jpg", "pkg/docs/report.pdf");
+                Set.of(
+                        "pkg/archive.tar",
+                        "pkg/picture.jpg",
+                        "pkg/docs/report.pdf");
 
         result.forEach(
                 (name, info) -> {

--- a/src/test/java/com/example/sourcecompare/DecompileServiceTest.java
+++ b/src/test/java/com/example/sourcecompare/DecompileServiceTest.java
@@ -5,6 +5,7 @@ import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -23,6 +24,7 @@ class DecompileServiceTest {
     void decompileClassesPreservesZipOrder() throws IOException {
         Map<String, byte[]> entries = new LinkedHashMap<>();
         entries.put("pkg/Foo.class", new byte[] {(byte) 30});
+        entries.put("pkg/readme.txt", "resource".getBytes(StandardCharsets.UTF_8));
         entries.put("pkg/Bar.class", new byte[] {(byte) 5});
         entries.put("pkg/Baz.class", new byte[] {(byte) 10});
 
@@ -48,8 +50,13 @@ class DecompileServiceTest {
         result.forEach(
                 (name, info) -> {
                     assertEquals(name, info.getName());
-                    int delay = Byte.toUnsignedInt(entries.get(name)[0]);
-                    assertEquals("delay-" + delay, info.getContent());
+                    byte[] originalBytes = entries.get(name);
+                    if (name.endsWith(".class")) {
+                        int delay = Byte.toUnsignedInt(originalBytes[0]);
+                        assertEquals("delay-" + delay, info.getContent());
+                    } else {
+                        assertEquals(new String(originalBytes, StandardCharsets.UTF_8), info.getContent());
+                    }
                 });
     }
 

--- a/src/test/java/com/example/sourcecompare/DecompileServiceTest.java
+++ b/src/test/java/com/example/sourcecompare/DecompileServiceTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.ZipEntry;
@@ -25,6 +26,9 @@ class DecompileServiceTest {
         Map<String, byte[]> entries = new LinkedHashMap<>();
         entries.put("pkg/Foo.class", new byte[] {(byte) 30});
         entries.put("pkg/readme.txt", "resource".getBytes(StandardCharsets.UTF_8));
+        entries.put("pkg/archive.tar", new byte[] {1, 2, 3});
+        entries.put("pkg/picture.jpg", new byte[] {4});
+        entries.put("pkg/docs/report.pdf", new byte[] {5, 6});
         entries.put("pkg/Bar.class", new byte[] {(byte) 5});
         entries.put("pkg/Baz.class", new byte[] {(byte) 10});
 
@@ -47,6 +51,9 @@ class DecompileServiceTest {
 
         assertEquals(entries.size(), result.size());
         assertIterableEquals(entries.keySet(), result.keySet(), "Decompiled files should follow ZIP order");
+        Set<String> placeholderEntries =
+                Set.of("pkg/archive.tar", "pkg/picture.jpg", "pkg/docs/report.pdf");
+
         result.forEach(
                 (name, info) -> {
                     assertEquals(name, info.getName());
@@ -54,6 +61,8 @@ class DecompileServiceTest {
                     if (name.endsWith(".class")) {
                         int delay = Byte.toUnsignedInt(originalBytes[0]);
                         assertEquals("delay-" + delay, info.getContent());
+                    } else if (placeholderEntries.contains(name)) {
+                        assertEquals("CONTENT_NOT_READ", info.getContent());
                     } else {
                         assertEquals(new String(originalBytes, StandardCharsets.UTF_8), info.getContent());
                     }


### PR DESCRIPTION
## Summary
- allow `DecompileService` to keep non-class archive entries with their original text instead of skipping them
- ensure decompilation still runs asynchronously for class files while preserving archive order for every entry
- expand the existing unit test to cover preserved content for non-class files

## Testing
- mvn -q test *(fails: cannot resolve Spring Boot parent POM without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b53fd80083258ff04b985ffe8128