### PR TITLE
Add fallback diff message for identical content

### DIFF
--- a/src/main/java/com/example/sourcecompare/ComparisonService.java
+++ b/src/main/java/com/example/sourcecompare/ComparisonService.java
@@ -19,6 +19,7 @@ import java.util.zip.ZipInputStream;
 @Service
 public class ComparisonService {
     private static final Logger log = LogManager.getLogger(ComparisonService.class);
+    private static final String NO_TEXTUAL_DIFFERENCES_MESSAGE = "No textual differences available.";
     @Autowired
     private GoogleFormatService googleFormatService;
     @Autowired
@@ -332,6 +333,14 @@ public class ComparisonService {
                         originalLines,
                         patch,
                         safeContextSize);
+        if (unified.isEmpty()) {
+            unified =
+                    List.of(
+                            String.format("--- %s_orig", fileName),
+                            String.format("+++ %s_rev", fileName),
+                            "@@ -0,0 +0,0 @@",
+                            " " + NO_TEXTUAL_DIFFERENCES_MESSAGE);
+        }
         return String.join(System.lineSeparator(), unified) + System.lineSeparator();
     }
 }

--- a/src/test/java/com/example/sourcecompare/ComparisonServiceTest.java
+++ b/src/test/java/com/example/sourcecompare/ComparisonServiceTest.java
@@ -1,0 +1,41 @@
+package com.example.sourcecompare;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComparisonServiceTest {
+
+    @Test
+    void generateDiffProducesFallbackWhenContentMatches() throws Exception {
+        ComparisonService service = new ComparisonService();
+        Method method =
+                ComparisonService.class.getDeclaredMethod(
+                        "generateDiff", String.class, String.class, String.class, int.class);
+        method.setAccessible(true);
+
+        String diff =
+                (String)
+                        method.invoke(
+                                service,
+                                "Example.java",
+                                "CONTENT_NOT_READ",
+                                "CONTENT_NOT_READ",
+                                3);
+
+        assertTrue(
+                diff.contains("--- Example.java_orig"),
+                "Diff should include original header when no textual differences exist.");
+        assertTrue(
+                diff.contains("+++ Example.java_rev"),
+                "Diff should include revised header when no textual differences exist.");
+        assertTrue(
+                diff.contains("@@ -0,0 +0,0 @@"),
+                "Diff should include synthetic hunk when no textual differences exist.");
+        assertTrue(
+                diff.contains("No textual differences available."),
+                "Diff should include explanatory message when no textual differences exist.");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `ComparisonService.generateDiff` returns a fallback diff when no textual changes are produced
- add a unit test covering identical input content so the fallback diff renders safely

## Testing
- `mvn test` *(fails: cannot resolve Spring Boot parent POM because Maven Central is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cd86eef48325aa20b1ba888b32c5