### PR TITLE
Refactor project into layered architecture

### DIFF
--- a/src/main/java/com/example/sourcecompare/application/ArchiveDecompiler.java
+++ b/src/main/java/com/example/sourcecompare/application/ArchiveDecompiler.java
@@ -1,0 +1,13 @@
+package com.example.sourcecompare.application;
+
+import com.example.sourcecompare.domain.ArchiveInput;
+import com.example.sourcecompare.domain.FileInfo;
+
+import java.io.IOException;
+import java.util.Map;
+
+public interface ArchiveDecompiler {
+    String CONTENT_NOT_READ = "CONTENT_NOT_READ";
+
+    Map<String, FileInfo> decompileClasses(ArchiveInput archive) throws IOException;
+}

--- a/src/main/java/com/example/sourcecompare/application/DiffRenderer.java
+++ b/src/main/java/com/example/sourcecompare/application/DiffRenderer.java
@@ -1,0 +1,10 @@
+package com.example.sourcecompare.application;
+
+public interface DiffRenderer {
+    String render(
+            String fileName,
+            String original,
+            String revised,
+            int contextSize,
+            String unreadPlaceholder);
+}

--- a/src/main/java/com/example/sourcecompare/application/JavaSourceNormalizer.java
+++ b/src/main/java/com/example/sourcecompare/application/JavaSourceNormalizer.java
@@ -1,0 +1,5 @@
+package com.example.sourcecompare.application;
+
+public interface JavaSourceNormalizer {
+    String normalizeJava(String source);
+}

--- a/src/main/java/com/example/sourcecompare/application/SourceFormatter.java
+++ b/src/main/java/com/example/sourcecompare/application/SourceFormatter.java
@@ -1,0 +1,7 @@
+package com.example.sourcecompare.application;
+
+import com.example.sourcecompare.domain.FileInfo;
+
+public interface SourceFormatter {
+    FileInfo formatFile(String name, String content);
+}

--- a/src/main/java/com/example/sourcecompare/domain/ArchiveInput.java
+++ b/src/main/java/com/example/sourcecompare/domain/ArchiveInput.java
@@ -1,0 +1,31 @@
+package com.example.sourcecompare.domain;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Represents an uploaded archive in a framework-agnostic way.
+ */
+public class ArchiveInput {
+    private final String filename;
+    private final InputStreamSupplier inputStreamSupplier;
+
+    public ArchiveInput(String filename, InputStreamSupplier inputStreamSupplier) {
+        this.filename = filename != null ? filename : "";
+        this.inputStreamSupplier = Objects.requireNonNull(inputStreamSupplier, "inputStreamSupplier");
+    }
+
+    public String filename() {
+        return filename;
+    }
+
+    public InputStream openStream() throws IOException {
+        return inputStreamSupplier.openStream();
+    }
+
+    @FunctionalInterface
+    public interface InputStreamSupplier {
+        InputStream openStream() throws IOException;
+    }
+}

--- a/src/main/java/com/example/sourcecompare/domain/ComparisonMode.java
+++ b/src/main/java/com/example/sourcecompare/domain/ComparisonMode.java
@@ -1,4 +1,4 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.domain;
 
 public enum ComparisonMode {
     CLASS_VS_SOURCE,

--- a/src/main/java/com/example/sourcecompare/domain/ComparisonRequest.java
+++ b/src/main/java/com/example/sourcecompare/domain/ComparisonRequest.java
@@ -1,0 +1,16 @@
+package com.example.sourcecompare.domain;
+
+import java.util.Objects;
+
+public record ComparisonRequest(
+        ArchiveInput left,
+        ArchiveInput right,
+        ComparisonMode mode,
+        int contextSize,
+        boolean includeUnchanged) {
+    public ComparisonRequest {
+        Objects.requireNonNull(left, "left");
+        Objects.requireNonNull(right, "right");
+        Objects.requireNonNull(mode, "mode");
+    }
+}

--- a/src/main/java/com/example/sourcecompare/domain/ComparisonResult.java
+++ b/src/main/java/com/example/sourcecompare/domain/ComparisonResult.java
@@ -1,4 +1,4 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.domain;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/example/sourcecompare/domain/DiffInfo.java
+++ b/src/main/java/com/example/sourcecompare/domain/DiffInfo.java
@@ -1,4 +1,4 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.domain;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/example/sourcecompare/domain/FileInfo.java
+++ b/src/main/java/com/example/sourcecompare/domain/FileInfo.java
@@ -1,4 +1,4 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.domain;
 
 /**
  * Simple container for file metadata used during comparisons.

--- a/src/main/java/com/example/sourcecompare/domain/RenameInfo.java
+++ b/src/main/java/com/example/sourcecompare/domain/RenameInfo.java
@@ -1,4 +1,4 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.domain;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/example/sourcecompare/infrastructure/ConsoleDecompilerPublic.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/ConsoleDecompilerPublic.java
@@ -1,4 +1,4 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.infrastructure;
 
 import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;

--- a/src/main/java/com/example/sourcecompare/infrastructure/EclipseFormatService.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/EclipseFormatService.java
@@ -1,5 +1,7 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.infrastructure;
 
+import com.example.sourcecompare.application.SourceFormatter;
+import com.example.sourcecompare.domain.FileInfo;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jface.text.BadLocationException;
@@ -8,7 +10,8 @@ import org.eclipse.text.edits.TextEdit;
 import org.springframework.stereotype.Service;
 
 @Service
-public class EclipseFormatService {
+public class EclipseFormatService implements SourceFormatter {
+    @Override
     public FileInfo formatFile(String name, String content) {
         String nameFormat = name.replace(".class", ".java");
         String contentFormat;

--- a/src/main/java/com/example/sourcecompare/infrastructure/GoogleFormatService.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/GoogleFormatService.java
@@ -1,14 +1,17 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.infrastructure;
 
+import com.example.sourcecompare.application.JavaSourceNormalizer;
+import com.example.sourcecompare.domain.ArchiveInput;
+import com.example.sourcecompare.domain.FileInfo;
 import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.objectweb.asm.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -16,7 +19,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 @Service
-public class GoogleFormatService {
+public class GoogleFormatService implements JavaSourceNormalizer {
+    @Override
     public String normalizeJava(String source) {
         try {
             source = new Formatter().formatSource(source);
@@ -65,9 +69,10 @@ public class GoogleFormatService {
         }
     }
 
-    public Map<String, FileInfo> classStructures(MultipartFile zip) throws IOException {
+    public Map<String, FileInfo> classStructures(ArchiveInput archive) throws IOException {
         Map<String, FileInfo> result = new HashMap<>();
-        try (ZipInputStream zis = new ZipInputStream(zip.getInputStream())) {
+        try (InputStream inputStream = archive.openStream();
+                ZipInputStream zis = new ZipInputStream(inputStream)) {
             ZipEntry entry;
             while ((entry = zis.getNextEntry()) != null) {
                 if (!entry.isDirectory() && entry.getName().endsWith(".class")) {

--- a/src/main/java/com/example/sourcecompare/infrastructure/UnifiedDiffRenderer.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/UnifiedDiffRenderer.java
@@ -1,0 +1,48 @@
+package com.example.sourcecompare.infrastructure;
+
+import com.example.sourcecompare.application.DiffRenderer;
+import com.github.difflib.DiffUtils;
+import com.github.difflib.UnifiedDiffUtils;
+import com.github.difflib.patch.Patch;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class UnifiedDiffRenderer implements DiffRenderer {
+    private static final String NO_TEXTUAL_DIFFERENCES_MESSAGE = "No textual differences available.";
+
+    @Override
+    public String render(
+            String fileName,
+            String original,
+            String revised,
+            int contextSize,
+            String unreadPlaceholder) {
+        List<String> originalLines = Arrays.asList(original.split("\\R"));
+        List<String> revisedLines = Arrays.asList(revised.split("\\R"));
+        Patch<String> patch = DiffUtils.diff(originalLines, revisedLines);
+        int safeContextSize = Math.max(0, contextSize);
+        List<String> unified =
+                UnifiedDiffUtils.generateUnifiedDiff(
+                        fileName + "_orig",
+                        fileName + "_rev",
+                        originalLines,
+                        patch,
+                        safeContextSize);
+        if (unified.isEmpty()) {
+            String content =
+                    original.equals(unreadPlaceholder)
+                            ? original
+                            : NO_TEXTUAL_DIFFERENCES_MESSAGE;
+            unified =
+                    List.of(
+                            String.format("--- %s_orig", fileName),
+                            String.format("+++ %s_rev", fileName),
+                            "@@ -0,0 +0,0 @@",
+                            " " + content);
+        }
+        return String.join(System.lineSeparator(), unified) + System.lineSeparator();
+    }
+}

--- a/src/main/java/com/example/sourcecompare/web/HomeController.java
+++ b/src/main/java/com/example/sourcecompare/web/HomeController.java
@@ -1,5 +1,9 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.web;
 
+import com.example.sourcecompare.application.ComparisonUseCase;
+import com.example.sourcecompare.domain.ComparisonMode;
+import com.example.sourcecompare.domain.ComparisonRequest;
+import com.example.sourcecompare.domain.ComparisonResult;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,10 +15,13 @@ import java.io.IOException;
 
 @Controller
 public class HomeController {
-    private final ComparisonService comparisonService;
+    private final ComparisonUseCase comparisonUseCase;
+    private final MultipartArchiveInputAdapter archiveInputAdapter;
 
-    public HomeController(ComparisonService comparisonService) {
-        this.comparisonService = comparisonService;
+    public HomeController(
+            ComparisonUseCase comparisonUseCase, MultipartArchiveInputAdapter archiveInputAdapter) {
+        this.comparisonUseCase = comparisonUseCase;
+        this.archiveInputAdapter = archiveInputAdapter;
     }
 
     @GetMapping("/")
@@ -32,8 +39,14 @@ public class HomeController {
             @RequestParam(name = "showUnchanged", defaultValue = "false") boolean showUnchanged,
             Model model)
             throws IOException {
-        ComparisonResult result =
-                comparisonService.compare(leftZip, rightZip, mode, contextSize, showUnchanged);
+        ComparisonRequest request =
+                new ComparisonRequest(
+                        archiveInputAdapter.adapt(leftZip),
+                        archiveInputAdapter.adapt(rightZip),
+                        mode,
+                        contextSize,
+                        showUnchanged);
+        ComparisonResult result = comparisonUseCase.compare(request);
         model.addAttribute(
                 "message",
                 String.format(

--- a/src/main/java/com/example/sourcecompare/web/MultipartArchiveInputAdapter.java
+++ b/src/main/java/com/example/sourcecompare/web/MultipartArchiveInputAdapter.java
@@ -1,0 +1,12 @@
+package com.example.sourcecompare.web;
+
+import com.example.sourcecompare.domain.ArchiveInput;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class MultipartArchiveInputAdapter {
+    public ArchiveInput adapt(MultipartFile file) {
+        return new ArchiveInput(file.getOriginalFilename(), file::getInputStream);
+    }
+}

--- a/src/test/java/com/example/sourcecompare/infrastructure/UnifiedDiffRendererTest.java
+++ b/src/test/java/com/example/sourcecompare/infrastructure/UnifiedDiffRendererTest.java
@@ -1,29 +1,23 @@
-package com.example.sourcecompare;
+package com.example.sourcecompare.infrastructure;
 
+import com.example.sourcecompare.application.ArchiveDecompiler;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ComparisonServiceTest {
+class UnifiedDiffRendererTest {
+
+    private final UnifiedDiffRenderer renderer = new UnifiedDiffRenderer();
 
     @Test
-    void generateDiffProducesFallbackWhenContentMatches() throws Exception {
-        ComparisonService service = new ComparisonService();
-        Method method =
-                ComparisonService.class.getDeclaredMethod(
-                        "generateDiff", String.class, String.class, String.class, int.class);
-        method.setAccessible(true);
-
+    void renderProducesFallbackWhenContentMatches() {
         String diff =
-                (String)
-                        method.invoke(
-                                service,
-                                "Example.java",
-                                "CONTENT_NOT_READ",
-                                "CONTENT_NOT_READ",
-                                3);
+                renderer.render(
+                        "Example.java",
+                        ArchiveDecompiler.CONTENT_NOT_READ,
+                        ArchiveDecompiler.CONTENT_NOT_READ,
+                        3,
+                        ArchiveDecompiler.CONTENT_NOT_READ);
 
         assertTrue(
                 diff.contains("--- Example.java_orig"),


### PR DESCRIPTION
## Summary
- introduce application, domain, infrastructure, and web packages and move existing components into their respective layers
- replace the old ComparisonService with a ComparisonUseCase that consumes framework-agnostic ArchiveInput/ComparisonRequest objects through new service interfaces
- adapt the infrastructure implementations and web controller to the new interfaces and add adapters/tests for MultipartFile conversion and diff rendering

## Testing
- `mvn test` *(fails: cannot download Spring Boot parent POM because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e6973d688325a9ae7e41b95854eb