### PR TITLE
Support multiple archives per side

### DIFF
--- a/src/main/java/com/example/sourcecompare/web/HomeController.java
+++ b/src/main/java/com/example/sourcecompare/web/HomeController.java
@@ -32,9 +32,9 @@ public class HomeController {
 
     @PostMapping("/compare")
     public String compare(
-            @RequestParam("leftZip") MultipartFile leftZip,
-            @RequestParam("rightZip") MultipartFile rightZip,
-            @RequestParam("mode") ComparisonMode mode,
+            @RequestParam("leftZip") MultipartFile[] leftZip,
+            @RequestParam("rightZip") MultipartFile[] rightZip,
+            @RequestParam(name = "mode", defaultValue = "CLASS_VS_CLASS") ComparisonMode mode,
             @RequestParam(name = "contextSize", defaultValue = "5") int contextSize,
             @RequestParam(name = "showUnchanged", defaultValue = "false") boolean showUnchanged,
             Model model)
@@ -51,7 +51,9 @@ public class HomeController {
                 "message",
                 String.format(
                         "Compared %s and %s using %s",
-                        leftZip.getOriginalFilename(), rightZip.getOriginalFilename(), mode));
+                        archiveInputAdapter.describeFilenames(leftZip),
+                        archiveInputAdapter.describeFilenames(rightZip),
+                        mode));
         model.addAttribute("result", result);
         return "diff";
     }

--- a/src/main/java/com/example/sourcecompare/web/MultipartArchiveInputAdapter.java
+++ b/src/main/java/com/example/sourcecompare/web/MultipartArchiveInputAdapter.java
@@ -4,9 +4,171 @@ import com.example.sourcecompare.domain.ArchiveInput;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
 @Component
 public class MultipartArchiveInputAdapter {
     public ArchiveInput adapt(MultipartFile file) {
         return new ArchiveInput(file.getOriginalFilename(), file::getInputStream);
+    }
+
+    public ArchiveInput adapt(MultipartFile[] files) throws IOException {
+        if (files == null || files.length == 0) {
+            throw new IllegalArgumentException("At least one file must be provided");
+        }
+        if (files.length == 1) {
+            return adapt(files[0]);
+        }
+        List<MultipartFile> fileList = new ArrayList<>(files.length);
+        for (MultipartFile file : files) {
+            if (file != null && !file.isEmpty()) {
+                fileList.add(file);
+            }
+        }
+        if (fileList.isEmpty()) {
+            throw new IllegalArgumentException("At least one non-empty file must be provided");
+        }
+        if (fileList.size() == 1) {
+            return adapt(fileList.get(0));
+        }
+        return adaptMultiple(fileList);
+    }
+
+    public String describeFilenames(MultipartFile[] files) {
+        if (files == null || files.length == 0) {
+            return "0 files";
+        }
+        List<String> names = new ArrayList<>();
+        for (MultipartFile file : files) {
+            if (file == null) {
+                continue;
+            }
+            String originalFilename = file.getOriginalFilename();
+            if (originalFilename != null && !originalFilename.isBlank()) {
+                names.add(originalFilename);
+            }
+        }
+        if (names.isEmpty()) {
+            return files.length == 1 ? "1 file" : files.length + " files";
+        }
+        return String.join(", ", names);
+    }
+
+    private ArchiveInput adaptMultiple(List<MultipartFile> files) throws IOException {
+        Path tempFile = Files.createTempFile("combined-archive", ".zip");
+        tempFile.toFile().deleteOnExit();
+        try {
+            writeCombinedArchive(tempFile, files);
+        } catch (IOException e) {
+            Files.deleteIfExists(tempFile);
+            throw e;
+        }
+        return new ArchiveInput(buildCombinedName(files), () -> Files.newInputStream(tempFile));
+    }
+
+    private void writeCombinedArchive(Path destination, List<MultipartFile> files) throws IOException {
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(destination))) {
+            byte[] buffer = new byte[8192];
+            Set<String> usedPrefixes = new HashSet<>();
+            for (int index = 0; index < files.size(); index++) {
+                MultipartFile file = files.get(index);
+                String prefix = ensureUniquePrefix(derivePrefix(file, index), usedPrefixes);
+                try (InputStream inputStream = file.getInputStream();
+                        ZipInputStream zis = new ZipInputStream(inputStream)) {
+                    ZipEntry entry;
+                    while ((entry = zis.getNextEntry()) != null) {
+                        if (entry.isDirectory()) {
+                            continue;
+                        }
+                        String entryName = sanitizeEntryName(entry.getName());
+                        if (entryName.isEmpty()) {
+                            continue;
+                        }
+                        ZipEntry newEntry = new ZipEntry(prefix + "/" + entryName);
+                        zos.putNextEntry(newEntry);
+                        int read;
+                        while ((read = zis.read(buffer)) != -1) {
+                            zos.write(buffer, 0, read);
+                        }
+                        zos.closeEntry();
+                    }
+                }
+            }
+        }
+    }
+
+    private String buildCombinedName(List<MultipartFile> files) {
+        String combined =
+                files.stream()
+                        .map(MultipartFile::getOriginalFilename)
+                        .filter(Objects::nonNull)
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(name -> stripExtension(name).replaceAll("[^A-Za-z0-9._-]", "_"))
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.joining("-"));
+        if (combined.isEmpty()) {
+            combined = "combined";
+        }
+        return combined + ".zip";
+    }
+
+    private String derivePrefix(MultipartFile file, int index) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.isBlank()) {
+            return "archive-" + (index + 1);
+        }
+        String sanitized = stripExtension(originalFilename).replaceAll("[^A-Za-z0-9._-]", "_");
+        if (sanitized.isBlank()) {
+            sanitized = "archive-" + (index + 1);
+        }
+        return sanitized;
+    }
+
+    private String ensureUniquePrefix(String prefix, Set<String> usedPrefixes) {
+        String candidate = prefix;
+        int counter = 1;
+        while (!usedPrefixes.add(candidate)) {
+            candidate = prefix + "-" + counter++;
+        }
+        return candidate;
+    }
+
+    private String stripExtension(String name) {
+        int slash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+        String simple = slash >= 0 ? name.substring(slash + 1) : name;
+        int dotIndex = simple.lastIndexOf('.');
+        if (dotIndex <= 0) {
+            return simple;
+        }
+        return simple.substring(0, dotIndex);
+    }
+
+    private String sanitizeEntryName(String entryName) {
+        String normalized = entryName.replace('\\', '/');
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        // Prevent directory traversal attempts
+        List<String> segments = new ArrayList<>();
+        for (String segment : normalized.split("/")) {
+            if (segment.equals("..") || segment.isEmpty()) {
+                continue;
+            }
+            segments.add(segment);
+        }
+        return String.join("/", segments);
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -37,15 +37,17 @@
             id="compareForm"
             method="post"
     >
+        <input name="mode" type="hidden" value="CLASS_VS_CLASS"/>
         <div class="row mb-3">
             <div class="col-md-6">
-                <label class="form-label" for="leftZip">Left ZIP</label>
+                <label class="form-label" for="leftZip">Left archives</label>
                 <div class="drop-zone mb-2" id="leftDropZone">
                     <span class="drop-zone-text">Drag &amp; drop or click to select</span>
                     <input
                             accept=".zip"
                             id="leftZip"
                             name="leftZip"
+                            multiple
                             required
                             style="display: none"
                             type="file"
@@ -56,13 +58,14 @@
                 </div>
             </div>
             <div class="col-md-6">
-                <label class="form-label" for="rightZip">Right ZIP</label>
+                <label class="form-label" for="rightZip">Right archives</label>
                 <div class="drop-zone mb-2" id="rightDropZone">
                     <span class="drop-zone-text">Drag &amp; drop or click to select</span>
                     <input
                             accept=".zip"
                             id="rightZip"
                             name="rightZip"
+                            multiple
                             required
                             style="display: none"
                             type="file"
@@ -70,21 +73,6 @@
                 </div>
                 <div class="form-text">
                     Upload the ZIP file representing the right side of the comparison.
-                </div>
-            </div>
-        </div>
-        <div class="row mb-3">
-            <div class="col-md-12">
-                <div aria-label="Comparison mode" class="btn-group" role="group">
-                    <input checked class="btn-check" id="modeClassClass" name="mode" type="radio"
-                           value="CLASS_VS_CLASS">
-                    <label class="btn btn-outline-primary" for="modeClassClass">Class vs Class</label>
-
-                    <input class="btn-check" id="modeClassSource" name="mode" type="radio" value="CLASS_VS_SOURCE">
-                    <label class="btn btn-outline-primary" for="modeClassSource">Class vs Source</label>
-
-                    <input class="btn-check" id="modeSourceSource" name="mode" type="radio" value="SOURCE_VS_SOURCE">
-                    <label class="btn btn-outline-primary" for="modeSourceSource">Source vs Source</label>
                 </div>
             </div>
         </div>
@@ -196,8 +184,13 @@
 
         input.addEventListener('change', () => {
             const text = dropZone.querySelector('.drop-zone-text');
-            if (input.files.length) {
-                text.textContent = input.files[0].name;
+            const {files} = input;
+            if (files.length) {
+                if (files.length === 1) {
+                    text.textContent = files[0].name;
+                } else {
+                    text.textContent = `${files.length} files selected`;
+                }
             } else {
                 text.textContent = 'Drag & drop or click to select';
             }


### PR DESCRIPTION
## Summary
- limit the index page to class vs class comparisons and allow selecting multiple archives for each side
- combine multiple uploaded archives server-side so the comparison pipeline can work with a single merged archive
- improve status messaging to reflect all selected filenames

## Testing
- mvn test *(fails: network is unreachable when downloading parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2ba4a28c8325b64edd9d667a5dac