### PR TITLE
Wrap single-file uploads into archives

### DIFF
--- a/src/main/java/com/example/sourcecompare/web/MultipartArchiveInputAdapter.java
+++ b/src/main/java/com/example/sourcecompare/web/MultipartArchiveInputAdapter.java
@@ -4,9 +4,67 @@ import com.example.sourcecompare.domain.ArchiveInput;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
 @Component
 public class MultipartArchiveInputAdapter {
     public ArchiveInput adapt(MultipartFile file) {
-        return new ArchiveInput(file.getOriginalFilename(), file::getInputStream);
+        String originalFilename = file.getOriginalFilename();
+        String safeFilename = originalFilename != null ? originalFilename : "";
+        String lowerCaseName = safeFilename.toLowerCase(Locale.ROOT);
+
+        if (lowerCaseName.endsWith(".zip") || lowerCaseName.endsWith(".jar")) {
+            return new ArchiveInput(safeFilename, file::getInputStream);
+        }
+
+        if (lowerCaseName.endsWith(".class") || lowerCaseName.endsWith(".java")) {
+            try {
+                byte[] content = file.getBytes();
+                String entryName = singleEntryName(originalFilename, lowerCaseName);
+                byte[] archiveBytes = createSingleEntryArchive(entryName, content);
+                return new ArchiveInput(safeFilename, () -> new ByteArrayInputStream(archiveBytes));
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to buffer uploaded file", e);
+            }
+        }
+
+        return new ArchiveInput(safeFilename, file::getInputStream);
+    }
+
+    private static byte[] createSingleEntryArchive(String entryName, byte[] content) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                ZipEntry entry = new ZipEntry(entryName);
+                zos.putNextEntry(entry);
+                zos.write(content);
+                zos.closeEntry();
+            }
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create in-memory archive", e);
+        }
+    }
+
+    private static String singleEntryName(String originalFilename, String lowerCaseName) {
+        if (originalFilename != null) {
+            String trimmed = originalFilename.trim();
+            if (!trimmed.isEmpty()) {
+                int lastSlash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+                String candidate = trimmed.substring(lastSlash + 1);
+                if (!candidate.isBlank()) {
+                    return candidate;
+                }
+            }
+        }
+
+        int extensionIndex = lowerCaseName.lastIndexOf('.');
+        String extension = extensionIndex >= 0 ? lowerCaseName.substring(extensionIndex) : "";
+        return "file" + extension;
     }
 }

--- a/src/test/java/com/example/sourcecompare/web/MultipartArchiveInputAdapterTests.java
+++ b/src/test/java/com/example/sourcecompare/web/MultipartArchiveInputAdapterTests.java
@@ -1,0 +1,96 @@
+package com.example.sourcecompare.web;
+
+import com.example.sourcecompare.application.ArchiveDecompiler;
+import com.example.sourcecompare.application.ComparisonUseCase;
+import com.example.sourcecompare.application.DiffRenderer;
+import com.example.sourcecompare.application.JavaSourceNormalizer;
+import com.example.sourcecompare.application.SourceFormatter;
+import com.example.sourcecompare.domain.ArchiveInput;
+import com.example.sourcecompare.domain.ComparisonMode;
+import com.example.sourcecompare.domain.ComparisonRequest;
+import com.example.sourcecompare.domain.ComparisonResult;
+import com.example.sourcecompare.domain.FileInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MultipartArchiveInputAdapterTests {
+    private final MultipartArchiveInputAdapter adapter = new MultipartArchiveInputAdapter();
+
+    private final JavaSourceNormalizer normalizer = source -> source;
+    private final SourceFormatter formatter = FileInfo::new;
+    private final DiffRenderer diffRenderer = (fileName, original, revised, contextSize, unreadPlaceholder) -> "diff";
+
+    @Test
+    void classUploadIsWrappedIntoArchive() throws IOException {
+        byte[] leftBytes = new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
+        byte[] rightBytes = new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBF};
+
+        ArchiveInput left =
+                adapter.adapt(
+                        new MockMultipartFile(
+                                "left", "Example.class", "application/java-vm", leftBytes));
+        ArchiveInput right =
+                adapter.adapt(
+                        new MockMultipartFile(
+                                "right", "Example.class", "application/java-vm", rightBytes));
+
+        ComparisonUseCase useCase =
+                new ComparisonUseCase(new RecordingArchiveDecompiler(), normalizer, formatter, diffRenderer);
+        ComparisonRequest request = new ComparisonRequest(left, right, ComparisonMode.CLASS_VS_CLASS, 1, false);
+
+        ComparisonResult result = useCase.compare(request);
+        assertNotNull(result);
+    }
+
+    @Test
+    void javaUploadIsWrappedIntoArchive() throws IOException {
+        ArchiveInput left =
+                adapter.adapt(
+                        new MockMultipartFile(
+                                "left",
+                                "Sample.java",
+                                "text/plain",
+                                "class Left {}".getBytes(StandardCharsets.UTF_8)));
+        ArchiveInput right =
+                adapter.adapt(
+                        new MockMultipartFile(
+                                "right",
+                                "Sample.java",
+                                "text/plain",
+                                "class Right {}".getBytes(StandardCharsets.UTF_8)));
+
+        ComparisonUseCase useCase =
+                new ComparisonUseCase(new RecordingArchiveDecompiler(), normalizer, formatter, diffRenderer);
+        ComparisonRequest request = new ComparisonRequest(left, right, ComparisonMode.SOURCE_VS_SOURCE, 0, false);
+
+        ComparisonResult result = useCase.compare(request);
+        assertNotNull(result);
+    }
+
+    private static final class RecordingArchiveDecompiler implements ArchiveDecompiler {
+        @Override
+        public Map<String, FileInfo> decompileClasses(ArchiveInput archive) throws IOException {
+            Map<String, FileInfo> result = new LinkedHashMap<>();
+            try (ZipInputStream zis = new ZipInputStream(archive.openStream())) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.isDirectory() && entry.getName().endsWith(".class")) {
+                        byte[] bytes = zis.readAllBytes();
+                        result.put(entry.getName(), new FileInfo(entry.getName(), "len:" + bytes.length));
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- wrap multipart `.class` and `.java` uploads in a synthetic single-entry ZIP before adapting them
- add a helper to create the in-memory archive so repeated stream access stays safe
- add adapter tests covering raw `.class` and `.java` uploads through `ComparisonUseCase`

## Testing
- mvn test *(fails: unable to download Spring Boot parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2dc1fe308325bf164040ebd0126d