### PR TITLE
Add checkboxes to diff file tree entries

### DIFF
--- a/src/main/resources/templates/diff.html
+++ b/src/main/resources/templates/diff.html
@@ -84,6 +84,11 @@
         margin-bottom: 0.25rem;
     }
 
+    .tree-file .form-check-input {
+        margin: 0;
+        cursor: pointer;
+    }
+
     .tree-file.active .tree-link {
         font-weight: 600;
     }
@@ -424,6 +429,12 @@
             const li = document.createElement('li');
             li.className = 'tree-file';
 
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.className = 'form-check-input tree-file-checkbox';
+            checkbox.id = `${item.id}-checkbox`;
+            checkbox.setAttribute('aria-label', `Select ${fileEntry.name}`);
+
             const link = document.createElement('a');
             link.href = `#${item.id}`;
             link.className = 'tree-link';
@@ -458,6 +469,7 @@
             badge.className = `badge ${statusInfo.badgeClass}`;
             badge.textContent = statusInfo.label;
 
+            li.appendChild(checkbox);
             li.appendChild(link);
             li.appendChild(badge);
             ul.appendChild(li);


### PR DESCRIPTION
## Summary
- add Bootstrap-styled checkboxes beside each file in the diff tree view
- ensure checkboxes have accessible labels and align with the existing layout

## Testing
- `mvn -q test` *(fails: repository requires network access to resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3cdcb5608325a137e5ba5435b689