### PR TITLE
Persist comparison results and add detail page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
         <!-- Lombok for boilerplate reduction -->
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -107,6 +112,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>23.4.0.24.05</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/example/sourcecompare/application/ComparisonResultPersistenceService.java
+++ b/src/main/java/com/example/sourcecompare/application/ComparisonResultPersistenceService.java
@@ -1,0 +1,70 @@
+package com.example.sourcecompare.application;
+
+import com.example.sourcecompare.domain.ComparisonResult;
+import com.example.sourcecompare.infrastructure.persistence.StoredComparisonResult;
+import com.example.sourcecompare.infrastructure.persistence.StoredComparisonResultRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+@Service
+public class ComparisonResultPersistenceService {
+    private final StoredComparisonResultRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public ComparisonResultPersistenceService(
+            StoredComparisonResultRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public long saveComparison(String name, String ipRequest, ComparisonResult result) {
+        StoredComparisonResult entity = new StoredComparisonResult();
+        entity.setName(name);
+        entity.setIpRequest(ipRequest);
+        entity.setDiffResultJson(toJson(result));
+        StoredComparisonResult saved = repository.save(entity);
+        return saved.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public StoredComparisonResultView loadComparison(long id) {
+        StoredComparisonResult entity =
+                repository
+                        .findById(id)
+                        .orElseThrow(
+                                () ->
+                                        new ResponseStatusException(
+                                                HttpStatus.NOT_FOUND, "Comparison not found"));
+        ComparisonResult result = fromJson(entity.getDiffResultJson());
+        return new StoredComparisonResultView(
+                entity.getId(), entity.getName(), entity.getIpRequest(), entity.getCreated(), result);
+    }
+
+    private String toJson(ComparisonResult result) {
+        try {
+            return objectMapper.writeValueAsString(result);
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to store comparison result", ex);
+        }
+    }
+
+    private ComparisonResult fromJson(String json) {
+        try {
+            return objectMapper.readValue(json, ComparisonResult.class);
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to read comparison result", ex);
+        }
+    }
+
+    public record StoredComparisonResultView(
+            Long id, String name, String ipRequest, LocalDateTime created, ComparisonResult result) {}
+}

--- a/src/main/java/com/example/sourcecompare/domain/ComparisonResult.java
+++ b/src/main/java/com/example/sourcecompare/domain/ComparisonResult.java
@@ -1,6 +1,7 @@
 package com.example.sourcecompare.domain;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.Map;
  */
 @Getter
 @Setter
+@NoArgsConstructor
 public class ComparisonResult {
     private Map<String, DiffInfo> added;
     private Map<String, DiffInfo> deleted;

--- a/src/main/java/com/example/sourcecompare/domain/ComparisonTiming.java
+++ b/src/main/java/com/example/sourcecompare/domain/ComparisonTiming.java
@@ -1,25 +1,21 @@
 package com.example.sourcecompare.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.List;
 
 /**
  * Summary of timing information for a comparison run.
  */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ComparisonTiming {
-    private final List<StepTiming> steps;
-    private final double totalDurationSeconds;
-
-    public ComparisonTiming(List<StepTiming> steps, double totalDurationSeconds) {
-        this.steps = steps;
-        this.totalDurationSeconds = totalDurationSeconds;
-    }
-
-    public List<StepTiming> getSteps() {
-        return steps;
-    }
-
-    public double getTotalDurationSeconds() {
-        return totalDurationSeconds;
-    }
+    private List<StepTiming> steps;
+    private double totalDurationSeconds;
 }
 

--- a/src/main/java/com/example/sourcecompare/domain/DiffInfo.java
+++ b/src/main/java/com/example/sourcecompare/domain/DiffInfo.java
@@ -1,6 +1,7 @@
 package com.example.sourcecompare.domain;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -8,6 +9,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@NoArgsConstructor
 public class DiffInfo {
     private String diff;
 

--- a/src/main/java/com/example/sourcecompare/domain/RenameInfo.java
+++ b/src/main/java/com/example/sourcecompare/domain/RenameInfo.java
@@ -1,6 +1,7 @@
 package com.example.sourcecompare.domain;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -8,6 +9,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@NoArgsConstructor
 public class RenameInfo {
     private String from;
     private String to;

--- a/src/main/java/com/example/sourcecompare/domain/StepTiming.java
+++ b/src/main/java/com/example/sourcecompare/domain/StepTiming.java
@@ -1,23 +1,19 @@
 package com.example.sourcecompare.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /**
  * Represents the elapsed time for a single comparison step.
  */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class StepTiming {
-    private final String label;
-    private final double durationSeconds;
-
-    public StepTiming(String label, double durationSeconds) {
-        this.label = label;
-        this.durationSeconds = durationSeconds;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public double getDurationSeconds() {
-        return durationSeconds;
-    }
+    private String label;
+    private double durationSeconds;
 }
 

--- a/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResult.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResult.java
@@ -1,0 +1,80 @@
+package com.example.sourcecompare.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "COMPARE_RESULTS")
+public class StoredComparisonResult {
+
+    @Id
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "compare_result_sequence")
+    @SequenceGenerator(
+            name = "compare_result_sequence",
+            sequenceName = "COMPARE_RESULT_SEQ",
+            allocationSize = 1)
+    private Long id;
+
+    @Column(name = "NAME", nullable = false)
+    private String name;
+
+    @Column(name = "IP_REQUEST", nullable = false)
+    private String ipRequest;
+
+    @Column(name = "CREATED", insertable = false, updatable = false)
+    private LocalDateTime created;
+
+    @Lob
+    @Column(name = "DIFF_RESULT", nullable = false)
+    private String diffResultJson;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getIpRequest() {
+        return ipRequest;
+    }
+
+    public void setIpRequest(String ipRequest) {
+        this.ipRequest = ipRequest;
+    }
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = created;
+    }
+
+    public String getDiffResultJson() {
+        return diffResultJson;
+    }
+
+    public void setDiffResultJson(String diffResultJson) {
+        this.diffResultJson = diffResultJson;
+    }
+}

--- a/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResultRepository.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResultRepository.java
@@ -1,0 +1,6 @@
+package com.example.sourcecompare.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoredComparisonResultRepository
+        extends JpaRepository<StoredComparisonResult, Long> {}

--- a/src/main/java/com/example/sourcecompare/web/HomeController.java
+++ b/src/main/java/com/example/sourcecompare/web/HomeController.java
@@ -1,5 +1,6 @@
 package com.example.sourcecompare.web;
 
+import com.example.sourcecompare.application.ComparisonResultPersistenceService;
 import com.example.sourcecompare.application.ComparisonUseCase;
 import com.example.sourcecompare.domain.ComparisonMode;
 import com.example.sourcecompare.domain.ComparisonRequest;
@@ -7,21 +8,27 @@ import com.example.sourcecompare.domain.ComparisonResult;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import jakarta.servlet.http.HttpServletRequest;
 
 @Controller
 public class HomeController {
     private final ComparisonUseCase comparisonUseCase;
     private final MultipartArchiveInputAdapter archiveInputAdapter;
+    private final ComparisonResultPersistenceService comparisonResultPersistenceService;
 
     public HomeController(
-            ComparisonUseCase comparisonUseCase, MultipartArchiveInputAdapter archiveInputAdapter) {
+            ComparisonUseCase comparisonUseCase,
+            MultipartArchiveInputAdapter archiveInputAdapter,
+            ComparisonResultPersistenceService comparisonResultPersistenceService) {
         this.comparisonUseCase = comparisonUseCase;
         this.archiveInputAdapter = archiveInputAdapter;
+        this.comparisonResultPersistenceService = comparisonResultPersistenceService;
     }
 
     @GetMapping("/")
@@ -37,7 +44,7 @@ public class HomeController {
             @RequestParam(name = "mode", defaultValue = "CLASS_VS_CLASS") ComparisonMode mode,
             @RequestParam(name = "contextSize", defaultValue = "5") int contextSize,
             @RequestParam(name = "showUnchanged", defaultValue = "false") boolean showUnchanged,
-            Model model)
+            HttpServletRequest httpRequest)
             throws IOException {
         ComparisonRequest request =
                 new ComparisonRequest(
@@ -47,14 +54,25 @@ public class HomeController {
                         contextSize,
                         showUnchanged);
         ComparisonResult result = comparisonUseCase.compare(request);
-        model.addAttribute(
-                "message",
+        String comparisonName =
                 String.format(
-                        "Compared %s and %s using %s",
+                        "%s vs %s",
                         archiveInputAdapter.describeFilenames(leftZip),
-                        archiveInputAdapter.describeFilenames(rightZip),
-                        mode));
-        model.addAttribute("result", result);
+                        archiveInputAdapter.describeFilenames(rightZip));
+        long id =
+                comparisonResultPersistenceService.saveComparison(
+                        comparisonName, httpRequest.getRemoteAddr(), result);
+        return "redirect:/compare-result/" + id;
+    }
+
+    @GetMapping("/compare-result/{id}")
+    public String viewComparison(@PathVariable("id") long id, Model model) {
+        var storedResult = comparisonResultPersistenceService.loadComparison(id);
+        model.addAttribute("message", storedResult.name());
+        model.addAttribute("result", storedResult.result());
+        model.addAttribute("comparisonId", storedResult.id());
+        model.addAttribute("ipRequest", storedResult.ipRequest());
+        model.addAttribute("created", storedResult.created());
         return "diff";
     }
 }

--- a/src/main/resources/templates/diff.html
+++ b/src/main/resources/templates/diff.html
@@ -166,9 +166,22 @@
     }
 </style>
 <div class="container-fluid mt-4">
-    <div class="d-flex flex-wrap gap-2 justify-content-between align-items-center">
-        <h1 class="mb-0" th:text="${message}">Comparison Result</h1>
-        <a class="btn btn-outline-secondary" href="/">Return to Index</a>
+    <div class="d-flex flex-wrap gap-3 justify-content-between align-items-center">
+        <div>
+            <p class="text-muted mb-1" th:if="${comparisonId != null}" th:text="'Comparison #' + ${comparisonId}">
+                Comparison #
+            </p>
+            <h1 class="mb-0" th:text="${message}">Comparison Result</h1>
+        </div>
+        <div class="ms-auto text-end">
+            <div class="text-muted" th:if="${created != null}" th:text="${#temporals.format(created, 'yyyy-MM-dd HH:mm:ss')}">
+                2024-01-01 10:00:00
+            </div>
+            <div class="text-muted" th:if="${ipRequest != null}" th:text="'Request IP: ' + ${ipRequest}">
+                Request IP: 127.0.0.1
+            </div>
+            <a class="btn btn-outline-secondary mt-2" href="/">Return to Index</a>
+        </div>
     </div>
     <div class="row mt-3">
         <div class="col-lg-3 mb-3">


### PR DESCRIPTION
## Summary
- add a JPA entity, repository, and service to persist comparison results with an Oracle sequence and JSON payloads
- update the compare workflow to store each run, redirect to `/compare-result/{id}`, and expose a retrieval endpoint
- enhance the diff view to show persisted metadata including comparison id, request IP, and creation timestamp

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download Spring Boot parent POM because the build environment cannot reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cec441d27c832595c7238a5e44675d