### PR TITLE
Remove legacy compare-result route

### DIFF
--- a/src/main/java/com/example/sourcecompare/application/ComparisonResultPersistenceService.java
+++ b/src/main/java/com/example/sourcecompare/application/ComparisonResultPersistenceService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ComparisonResultPersistenceService {
@@ -47,6 +49,18 @@ public class ComparisonResultPersistenceService {
                 entity.getId(), entity.getName(), entity.getIpRequest(), entity.getCreated(), result);
     }
 
+    @Transactional(readOnly = true)
+    public List<StoredComparisonResultSummary> loadRecentComparisons() {
+        return repository
+                .findTop20ByOrderByCreatedDesc()
+                .stream()
+                .map(
+                        result ->
+                                new StoredComparisonResultSummary(
+                                        result.getId(), result.getName(), result.getCreated()))
+                .collect(Collectors.toList());
+    }
+
     private String toJson(ComparisonResult result) {
         try {
             return objectMapper.writeValueAsString(result);
@@ -67,4 +81,6 @@ public class ComparisonResultPersistenceService {
 
     public record StoredComparisonResultView(
             Long id, String name, String ipRequest, LocalDateTime created, ComparisonResult result) {}
+
+    public record StoredComparisonResultSummary(Long id, String name, LocalDateTime created) {}
 }

--- a/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResultRepository.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResultRepository.java
@@ -2,5 +2,9 @@ package com.example.sourcecompare.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StoredComparisonResultRepository
-        extends JpaRepository<StoredComparisonResult, Long> {}
+        extends JpaRepository<StoredComparisonResult, Long> {
+    List<StoredComparisonResult> findTop20ByOrderByCreatedDesc();
+}

--- a/src/main/java/com/example/sourcecompare/web/HomeController.java
+++ b/src/main/java/com/example/sourcecompare/web/HomeController.java
@@ -34,6 +34,8 @@ public class HomeController {
     @GetMapping("/")
     public String index(Model model) {
         model.addAttribute("message", "Source Compare Initialized");
+        model.addAttribute(
+                "recentComparisons", comparisonResultPersistenceService.loadRecentComparisons());
         return "index";
     }
 
@@ -62,10 +64,10 @@ public class HomeController {
         long id =
                 comparisonResultPersistenceService.saveComparison(
                         comparisonName, httpRequest.getRemoteAddr(), result);
-        return "redirect:/compare-result/" + id;
+        return "redirect:/compare/" + id;
     }
 
-    @GetMapping("/compare-result/{id}")
+    @GetMapping("/compare/{id}")
     public String viewComparison(@PathVariable("id") long id, Model model) {
         var storedResult = comparisonResultPersistenceService.loadComparison(id);
         model.addAttribute("message", storedResult.name());

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -30,6 +30,29 @@
 <div class="container mt-4">
     <h1 th:text="${message}">Source Compare Initialized</h1>
 
+    <div class="mt-4">
+        <h2>Recent comparisons</h2>
+        <div th:if="${#lists.isEmpty(recentComparisons)}">
+            <p class="text-muted mb-0">No comparisons have been run yet.</p>
+        </div>
+        <ul class="list-group" th:if="${!#lists.isEmpty(recentComparisons)}">
+            <li
+                    class="list-group-item d-flex justify-content-between align-items-center"
+                    th:each="comparison : ${recentComparisons}"
+            >
+                <a th:href="@{|/compare/${comparison.id}|}" th:text="${comparison.name}">
+                    Comparison name
+                </a>
+                <span
+                        class="badge bg-secondary"
+                        th:text="${#temporals.format(comparison.created, 'yyyy-MM-dd HH:mm')}"
+                >
+                    2024-01-01 00:00
+                </span>
+            </li>
+        </ul>
+    </div>
+
     <form
             action="/compare"
             class="mt-3"


### PR DESCRIPTION
## Summary
- simplify the comparison detail endpoint to only expose `/compare/{id}`

## Testing
- `mvn -q test` *(fails: Maven Central is unreachable in this environment, preventing dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68cec7e0798c8325a5250f155d6e5e85