### PR TITLE
Add mark color support to stored comparisons

### DIFF
--- a/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResult.java
+++ b/src/main/java/com/example/sourcecompare/infrastructure/persistence/StoredComparisonResult.java
@@ -38,6 +38,9 @@ public class StoredComparisonResult {
     @Column(name = "DIFF_RESULT", nullable = false)
     private String diffResultJson;
 
+    @Column(name = "MARK_COLOR")
+    private String markColor;
+
     public Long getId() {
         return id;
     }
@@ -76,5 +79,13 @@ public class StoredComparisonResult {
 
     public void setDiffResultJson(String diffResultJson) {
         this.diffResultJson = diffResultJson;
+    }
+
+    public String getMarkColor() {
+        return markColor;
+    }
+
+    public void setMarkColor(String markColor) {
+        this.markColor = markColor;
     }
 }

--- a/src/main/java/com/example/sourcecompare/web/HomeController.java
+++ b/src/main/java/com/example/sourcecompare/web/HomeController.java
@@ -68,13 +68,29 @@ public class HomeController {
     }
 
     @GetMapping("/compare/{id}")
-    public String viewComparison(@PathVariable("id") long id, Model model) {
+    public String viewComparison(@PathVariable("id") long id, Model model, HttpServletRequest request) {
         var storedResult = comparisonResultPersistenceService.loadComparison(id);
         model.addAttribute("message", storedResult.name());
         model.addAttribute("result", storedResult.result());
         model.addAttribute("comparisonId", storedResult.id());
         model.addAttribute("ipRequest", storedResult.ipRequest());
         model.addAttribute("created", storedResult.created());
+        model.addAttribute("markColor", storedResult.markColor());
+        model.addAttribute("markColorLabel", storedResult.markColorLabel());
+        model.addAttribute(
+                "markColorOptions", comparisonResultPersistenceService.getAvailableMarkColors());
+        model.addAttribute(
+                "canEditMarkColor", storedResult.ipRequest() != null
+                        && storedResult.ipRequest().equals(request.getRemoteAddr()));
         return "diff";
+    }
+
+    @PostMapping("/compare/{id}/mark-color")
+    public String updateMarkColor(
+            @PathVariable("id") long id,
+            @RequestParam("markColor") String markColor,
+            HttpServletRequest request) {
+        comparisonResultPersistenceService.updateMarkColor(id, request.getRemoteAddr(), markColor);
+        return "redirect:/compare/" + id;
     }
 }

--- a/src/main/resources/templates/diff.html
+++ b/src/main/resources/templates/diff.html
@@ -156,6 +156,14 @@
         border-left-color: #6c757d;
     }
 
+    .mark-color-preview {
+        width: 1.5rem;
+        height: 1.5rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        display: inline-block;
+    }
+
     @keyframes diff-highlight {
         from {
             background-color: #fff3cd;
@@ -165,7 +173,10 @@
         }
     }
 </style>
-<div class="container-fluid mt-4">
+<div
+        class="container-fluid mt-4"
+        th:with="displayColor=${markColor}, displayLabel=${markColorLabel}"
+>
     <div class="d-flex flex-wrap gap-3 justify-content-between align-items-center">
         <div>
             <p class="text-muted mb-1" th:if="${comparisonId != null}" th:text="'Comparison #' + ${comparisonId}">
@@ -179,6 +190,46 @@
             </div>
             <div class="text-muted" th:if="${ipRequest != null}" th:text="'Request IP: ' + ${ipRequest}">
                 Request IP: 127.0.0.1
+            </div>
+            <form
+                    th:if="${canEditMarkColor}"
+                    th:action="@{|/compare/${comparisonId}/mark-color|}"
+                    method="post"
+                    class="d-flex flex-wrap align-items-center gap-2 justify-content-end mt-2"
+            >
+                <label class="form-label mb-0" for="markColorInput">Mark color</label>
+                <span
+                        class="mark-color-preview"
+                        id="markColorPreview"
+                        th:style="'background-color:' + ${displayColor}"
+                ></span>
+                <select
+                        class="form-select form-select-sm w-auto"
+                        id="markColorInput"
+                        name="markColor"
+                        required
+                        th:value="${displayColor}"
+                >
+                    <option
+                            th:each="option : ${markColorOptions}"
+                            th:text="${option.label}"
+                            th:value="${option.value}"
+                    >
+                        Blue
+                    </option>
+                </select>
+                <span class="text-muted small" id="markColorLabel" th:text="${displayLabel}">
+                    Blue
+                </span>
+                <button class="btn btn-primary btn-sm" type="submit">Update color</button>
+            </form>
+            <div
+                    class="d-flex align-items-center gap-2 justify-content-end mt-2"
+                    th:if="${!canEditMarkColor}"
+            >
+                <span class="text-muted">Mark color</span>
+                <span class="mark-color-preview" th:style="'background-color:' + ${displayColor}"></span>
+                <span class="text-muted small" th:text="${displayLabel}">Blue</span>
             </div>
             <a class="btn btn-outline-secondary mt-2" href="/">Return to Index</a>
         </div>
@@ -208,6 +259,31 @@
     const diffSections = new Map();
     let activeTreeItem = null;
     let directoryIdCounter = 0;
+
+    const markColorInput = document.getElementById('markColorInput');
+    const markColorPreview = document.getElementById('markColorPreview');
+    const markColorLabel = document.getElementById('markColorLabel');
+
+    if (markColorInput && markColorPreview && markColorLabel) {
+        const updateMarkColorDisplay = (value, label) => {
+            if (!value) {
+                return;
+            }
+            markColorPreview.style.backgroundColor = value;
+            markColorLabel.textContent = label || value;
+        };
+
+        const selectedOption = markColorInput.options[markColorInput.selectedIndex];
+        updateMarkColorDisplay(
+                markColorInput.value,
+                selectedOption ? selectedOption.textContent : markColorInput.value,
+        );
+
+        markColorInput.addEventListener('change', (event) => {
+            const option = event.target.options[event.target.selectedIndex];
+            updateMarkColorDisplay(event.target.value, option ? option.textContent : event.target.value);
+        });
+    }
 
     const STATUS_INFO = {
         added: {label: 'Added', badgeClass: 'bg-success', headingClass: 'diff-heading-added'},

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -24,6 +24,14 @@
         .drop-zone.dragover {
             background-color: #e9ecef;
         }
+
+        .comparison-color {
+            width: 1.25rem;
+            height: 1.25rem;
+            border-radius: 50%;
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            display: inline-block;
+        }
     </style>
 </head>
 <body>
@@ -40,9 +48,16 @@
                     class="list-group-item d-flex justify-content-between align-items-center"
                     th:each="comparison : ${recentComparisons}"
             >
-                <a th:href="@{|/compare/${comparison.id}|}" th:text="${comparison.name}">
-                    Comparison name
-                </a>
+                <div class="d-flex align-items-center gap-2">
+                    <span
+                            class="comparison-color"
+                            th:style="'background-color:' + ${comparison.markColor}"
+                            th:title="${comparison.markColorLabel}"
+                    ></span>
+                    <a th:href="@{|/compare/${comparison.id}|}" th:text="${comparison.name}">
+                        Comparison name
+                    </a>
+                </div>
                 <span
                         class="badge bg-secondary"
                         th:text="${#temporals.format(comparison.created, 'yyyy-MM-dd HH:mm')}"


### PR DESCRIPTION
## Summary
- add a mark color column to stored comparison results and include it in persistence APIs
- render each comparison's color on the index page and expose the value in the detail view
- allow the comparison owner to update the mark color with a live preview in the comparison page using a predefined palette of eight named colors

## Testing
- mvn -q test *(fails: cannot reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cecc1c37a08325b9c3accf8bac864c