### PR TITLE
Enable editing comparison metadata

### DIFF
--- a/src/main/java/com/example/sourcecompare/application/ComparisonResultPersistenceService.java
+++ b/src/main/java/com/example/sourcecompare/application/ComparisonResultPersistenceService.java
@@ -108,7 +108,7 @@ public class ComparisonResultPersistenceService {
     }
 
     @Transactional
-    public void updateMarkColor(long id, String requesterIp, String markColor) {
+    public void updateComparison(long id, String requesterIp, String markColor, String name) {
         StoredComparisonResult entity =
                 repository
                         .findById(id)
@@ -121,11 +121,20 @@ public class ComparisonResultPersistenceService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not allowed to edit this comparison");
         }
 
-        if (!isValidMarkColor(markColor)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid color value");
+        if (markColor != null) {
+            if (!isValidMarkColor(markColor)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid color value");
+            }
+            entity.setMarkColor(markColor);
         }
 
-        entity.setMarkColor(markColor);
+        if (name != null) {
+            String sanitizedName = name.trim();
+            if (sanitizedName.isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Name cannot be empty");
+            }
+            entity.setName(sanitizedName);
+        }
     }
 
     private String toJson(ComparisonResult result) {

--- a/src/main/java/com/example/sourcecompare/web/HomeController.java
+++ b/src/main/java/com/example/sourcecompare/web/HomeController.java
@@ -90,17 +90,19 @@ public class HomeController {
         model.addAttribute(
                 "markColorOptions", comparisonResultPersistenceService.getAvailableMarkColors());
         model.addAttribute(
-                "canEditMarkColor", storedResult.ipRequest() != null
+                "canEditComparison", storedResult.ipRequest() != null
                         && storedResult.ipRequest().equals(request.getRemoteAddr()));
         return "diff";
     }
 
-    @PostMapping("/compare/{id}/mark-color")
-    public String updateMarkColor(
+    @PostMapping("/compare/{id}/edit")
+    public String updateComparison(
             @PathVariable("id") long id,
-            @RequestParam("markColor") String markColor,
+            @RequestParam(name = "markColor", required = false) String markColor,
+            @RequestParam(name = "name", required = false) String name,
             HttpServletRequest request) {
-        comparisonResultPersistenceService.updateMarkColor(id, request.getRemoteAddr(), markColor);
+        comparisonResultPersistenceService.updateComparison(
+                id, request.getRemoteAddr(), markColor, name);
         return "redirect:/compare/" + id;
     }
 }

--- a/src/main/resources/templates/diff.html
+++ b/src/main/resources/templates/diff.html
@@ -192,11 +192,21 @@
                 Request IP: 127.0.0.1
             </div>
             <form
-                    th:if="${canEditMarkColor}"
-                    th:action="@{|/compare/${comparisonId}/mark-color|}"
+                    th:if="${canEditComparison}"
+                    th:action="@{|/compare/${comparisonId}/edit|}"
                     method="post"
                     class="d-flex flex-wrap align-items-center gap-2 justify-content-end mt-2"
             >
+                <label class="form-label mb-0" for="nameInput">Name</label>
+                <input
+                        class="form-control form-control-sm w-auto"
+                        id="nameInput"
+                        maxlength="255"
+                        name="name"
+                        required
+                        th:value="${message}"
+                        type="text"
+                />
                 <label class="form-label mb-0" for="markColorInput">Mark color</label>
                 <span
                         class="mark-color-preview"
@@ -208,12 +218,12 @@
                         id="markColorInput"
                         name="markColor"
                         required
-                        th:value="${displayColor}"
                 >
                     <option
                             th:each="option : ${markColorOptions}"
                             th:text="${option.label}"
                             th:value="${option.value}"
+                            th:selected="${option.value == displayColor}"
                     >
                         Blue
                     </option>
@@ -221,11 +231,11 @@
                 <span class="text-muted small" id="markColorLabel" th:text="${displayLabel}">
                     Blue
                 </span>
-                <button class="btn btn-primary btn-sm" type="submit">Update color</button>
+                <button class="btn btn-primary btn-sm" type="submit">Save changes</button>
             </form>
             <div
                     class="d-flex align-items-center gap-2 justify-content-end mt-2"
-                    th:if="${!canEditMarkColor}"
+                    th:if="${!canEditComparison}"
             >
                 <span class="text-muted">Mark color</span>
                 <span class="mark-color-preview" th:style="'background-color:' + ${displayColor}"></span>


### PR DESCRIPTION
## Summary
- switch the comparison update endpoint to `/compare/{id}/edit`
- allow the comparison name and mark color to be updated with ownership validation
- expose name editing controls in the diff page and default the color selector to the current value

## Testing
- mvn -q test *(fails: network unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d1608498188325a3ceb03af12b4316